### PR TITLE
Improve build instructions to utilize parallel compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ git clone https://github.com/h3ssan/DjangoCPP.git
 cd DjangoCPP
 
 # Build the project
-make
+make -j$(nproc)
 
 # Run the server
 ./main


### PR DESCRIPTION
Include `-j$(nproc)` in the make command to utilize parallel compilation.