### PR TITLE
Convert DjangoCPP to a CMake library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,10 +29,12 @@ set(SRC_FILES
     ${PROJECT_SOURCE_DIR}/src/router.cc
 )
 
-add_executable(djangocpp ${SRC_FILES})
+add_library(djangocpp ${SRC_FILES})
 
-# Enable LTO if requested
-if(ENABLE_LTO)
-    message(STATUS "LTO enabled")
-    set_property(TARGET djangocpp PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
-endif()
+set_target_properties(djangocpp PROPERTIES
+    OUTPUT_NAME "djangocpp"
+    POSITION_INDEPENDENT_CODE ON
+)
+
+install(TARGETS djangocpp DESTINATION lib)
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/ DESTINATION include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ option(ENABLE_LTO "Enable Link Time Optimization" ON)
 if(CMAKE_BUILD_TYPE MATCHES Debug)
     set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g3" CACHE STRING "Debug flags" FORCE)
 elseif(CMAKE_BUILD_TYPE MATCHES Release)
-    set(CMAKE_CXX_FLAGS_RELEASE "-O3 -flto -s" CACHE STRING "Release flags" FORCE)
+    set(CMAKE_CXX_FLAGS_RELEASE "-O3 -s" CACHE STRING "Release flags" FORCE)
 endif()
 
 set(SRC_FILES

--- a/README.md
+++ b/README.md
@@ -31,6 +31,27 @@ DjangoCPP is a lightweight, educational web framework written in modern C++23 th
 
 ### Building
 
+#### Static Linking (default)
+
+```bash
+# Clone the repository
+git clone https://github.com/h3ssan/DjangoCPP.git
+cd DjangoCPP
+
+# Create a build directory
+mkdir build && cd build
+
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF ..
+
+# Build the project
+make -j$(nproc)
+
+# Install the library and headers
+sudo make install
+```
+
+#### Dynamic Linking
+
 ```bash
 # Clone the repository
 git clone https://github.com/h3ssan/DjangoCPP.git
@@ -40,16 +61,39 @@ cd DjangoCPP
 mkdir build && cd build
 
 # Configure the project
-cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON ..
 
 # Build the project
 make -j$(nproc)
 
-# Run the server
-./djangocpp
+# Install the library and headers
+sudo make install
 ```
 
-The server will start at `http://127.0.0.1:8000`
+### Example Application
+
+```cpp
+#include "djangocpp/http.h"
+
+int main() {
+    run_server();
+
+    return EXIT_SUCCESS;
+}
+```
+
+```cmake
+cmake_minimum_required(VERSION 3.10)
+
+project(myapp)
+
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_FLAGS "-Wall -Wextra -Werror -s")
+
+add_executable(myapp main.cc)
+
+target_link_libraries(myapp PRIVATE djangocpp)
+```
 
 ### Testing
 


### PR DESCRIPTION
This PR refactors **DjangoCPP** from a test‑only binary into an installable **statically‑linked library** built with CMake.  

### Overview  
- **CMake conversion:** switched from `add_executable` to `add_library(...)`, added proper install rules for the library archive and public headers.  
- **Documentation:** updated README with build, install, and usage instructions for downstream CMake projects.  

### Why this change?  
- Allows other projects to **reuse** DjangoCPP without recompiling the whole source tree.  
- Provides a standard static‑library distribution, simplifying dependency management and packaging.  

### Goals

- [X] Convert DjangoCPP into a library